### PR TITLE
Fix: comment out ledger, etherscan functionality

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -83,8 +83,8 @@ pub struct TestArgs {
     pub fail_fast: bool,
 
     /// The Etherscan (or equivalent) API key
-    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
-    etherscan_api_key: Option<String>,
+    // #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+    // etherscan_api_key: Option<String>,
 
     /// List tests instead of running them
     #[clap(long, short, help_heading = "Display options")]
@@ -140,8 +140,8 @@ impl TestArgs {
         let mut project = config.project()?;
 
         // install missing dependencies
-        if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
-            config.auto_detect_remappings
+        if install::install_missing_dependencies(&mut config, self.build_args().silent)
+            && config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config();
@@ -294,9 +294,9 @@ impl Provider for TestArgs {
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
-        if let Some(ref etherscan_api_key) = self.etherscan_api_key {
-            dict.insert("etherscan_api_key".to_string(), etherscan_api_key.to_string().into());
-        }
+        // if let Some(ref etherscan_api_key) = self.etherscan_api_key {
+        //     dict.insert("etherscan_api_key".to_string(), etherscan_api_key.to_string().into());
+        // }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
@@ -376,7 +376,7 @@ impl TestOutcome {
     pub fn ensure_ok(&self) -> eyre::Result<()> {
         let failures = self.failures().count();
         if self.allow_failure || failures == 0 {
-            return Ok(())
+            return Ok(());
         }
 
         if !shell::verbosity().is_normal() {
@@ -389,7 +389,7 @@ impl TestOutcome {
         for (suite_name, suite) in self.results.iter() {
             let failures = suite.failures().count();
             if failures == 0 {
-                continue
+                continue;
             }
 
             let term = if failures > 1 { "tests" } else { "test" };
@@ -542,9 +542,9 @@ async fn test(
     } else {
         // Set up identifiers
         let mut local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
-        let remote_chain_id = runner.evm_opts.get_remote_chain_id();
+        // let remote_chain_id = runner.evm_opts.get_remote_chain_id();
         // Do not re-query etherscan for contracts that you've already queried today.
-        let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
+        // let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
 
         // Set up test reporter channel
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -579,7 +579,7 @@ async fn test(
 
                 // If the test failed, we want to stop processing the rest of the tests
                 if fail_fast && result.status == TestStatus::Failure {
-                    break 'outer
+                    break 'outer;
                 }
 
                 // We only display logs at level 2 and above
@@ -612,7 +612,7 @@ async fn test(
                     let mut decoded_traces = Vec::new();
                     for (kind, trace) in &mut result.traces {
                         decoder.identify(trace, &mut local_identifier);
-                        decoder.identify(trace, &mut etherscan_identifier);
+                        // decoder.identify(trace, &mut etherscan_identifier);
 
                         let should_include = match kind {
                             // At verbosity level 3, we only display traces for failed tests
@@ -620,12 +620,12 @@ async fn test(
                             // tests At verbosity level 5, we display
                             // all traces for all tests
                             TraceKind::Setup => {
-                                (verbosity >= 5) ||
-                                    (verbosity == 4 && result.status == TestStatus::Failure)
+                                (verbosity >= 5)
+                                    || (verbosity == 4 && result.status == TestStatus::Failure)
                             }
                             TraceKind::Execution => {
-                                verbosity > 3 ||
-                                    (verbosity == 3 && result.status == TestStatus::Failure)
+                                verbosity > 3
+                                    || (verbosity == 3 && result.status == TestStatus::Failure)
                             }
                             _ => false,
                         };

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -129,40 +129,41 @@ impl figment::Provider for VerifyArgs {
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(mut self) -> eyre::Result<()> {
-        let config = self.load_config_emit_warnings();
-        let chain = config.chain_id.unwrap_or_default();
-        self.etherscan.chain = Some(chain);
-        self.etherscan.key = config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
-
-        if self.show_standard_json_input {
-            let args =
-                EtherscanVerificationProvider::default().create_verify_request(&self, None).await?;
-            println!("{}", args.source);
-            return Ok(())
-        }
-
-        let verifier_url = self.verifier.verifier_url.clone();
-        println!("Start verifying contract `{:?}` deployed on {chain}", self.address);
-        self.verifier.verifier.client(&self.etherscan.key)?.verify(self).await.map_err(|err| {
-            if let Some(verifier_url) = verifier_url {
-                 match Url::parse(&verifier_url) {
-                    Ok(url) => {
-                        if is_host_only(&url) {
-                            return err.wrap_err(format!(
-                                "Provided URL `{verifier_url}` is host only.\n Did you mean to use the API endpoint`{verifier_url}/api` ?"
-                            ))
-                        }
-                    }
-                    Err(url_err) => {
-                        return err.wrap_err(format!(
-                            "Invalid URL {verifier_url} provided: {url_err}"
-                        ))
-                    }
-                }
-            }
-
-            err
-        })
+        // let config = self.load_config_emit_warnings();
+        // let chain = config.chain_id.unwrap_or_default();
+        // self.etherscan.chain = Some(chain);
+        // self.etherscan.key = config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
+        //
+        // if self.show_standard_json_input {
+        //     let args =
+        //         EtherscanVerificationProvider::default().create_verify_request(&self, None).await?;
+        //     println!("{}", args.source);
+        //     return Ok(());
+        // }
+        //
+        // let verifier_url = self.verifier.verifier_url.clone();
+        // println!("Start verifying contract `{:?}` deployed on {chain}", self.address);
+        // self.verifier.verifier.client(&self.etherscan.key)?.verify(self).await.map_err(|err| {
+        //     if let Some(verifier_url) = verifier_url {
+        //          match Url::parse(&verifier_url) {
+        //             Ok(url) => {
+        //                 if is_host_only(&url) {
+        //                     return err.wrap_err(format!(
+        //                         "Provided URL `{verifier_url}` is host only.\n Did you mean to use the API endpoint`{verifier_url}/api` ?"
+        //                     ))
+        //                 }
+        //             }
+        //             Err(url_err) => {
+        //                 return err.wrap_err(format!(
+        //                     "Invalid URL {verifier_url} provided: {url_err}"
+        //                 ))
+        //             }
+        //         }
+        //     }
+        //
+        //     err
+        // })
+        Ok(())
     }
 
     /// Returns the configured verification provider

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -231,7 +231,7 @@ impl MultiWallet {
                     local_wallets.insert(address, signer);
 
                     if addresses.is_empty() {
-                        return Ok(local_wallets)
+                        return Ok(local_wallets);
                     }
                 } else {
                     // Just to show on error.
@@ -262,7 +262,7 @@ impl MultiWallet {
             for _ in 0..self.interactives {
                 wallets.push(self.get_from_interactive()?);
             }
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -273,7 +273,7 @@ impl MultiWallet {
             for private_key in private_keys.iter() {
                 wallets.push(self.get_from_private_key(private_key.trim())?);
             }
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -294,7 +294,7 @@ impl MultiWallet {
             for path in keystore_paths {
                 wallets.push(self.get_from_keystore(Some(path), passwords_iter.next().as_ref(), password_files_iter.next().as_ref())?.wrap_err("Keystore paths do not have the same length as provided passwords or password files.")?);
             }
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -329,7 +329,7 @@ impl MultiWallet {
                     mnemonic_index,
                 )?)
             }
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -346,7 +346,7 @@ impl MultiWallet {
             }
 
             create_hw_wallets!(args, chain_id, get_from_ledger, wallets);
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -354,7 +354,7 @@ impl MultiWallet {
     pub async fn trezors(&self, chain_id: u64) -> Result<Option<Vec<Trezor>>> {
         if self.trezor {
             create_hw_wallets!(self, chain_id, get_from_trezor, wallets);
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -376,7 +376,7 @@ impl MultiWallet {
                 wallets.push(aws_signer)
             }
 
-            return Ok(Some(wallets))
+            return Ok(Some(wallets));
         }
         Ok(None)
     }
@@ -401,13 +401,14 @@ impl MultiWallet {
         hd_path: Option<&str>,
         mnemonic_index: Option<usize>,
     ) -> Result<Option<Ledger>> {
-        let derivation = match hd_path {
-            Some(hd_path) => LedgerHDPath::Other(hd_path.to_string()),
-            None => LedgerHDPath::LedgerLive(mnemonic_index.unwrap_or(0)),
-        };
-
-        trace!(?chain_id, "Creating new ledger signer");
-        Ok(Some(Ledger::new(derivation, chain_id).await.wrap_err("Ledger device not available.")?))
+        // let derivation = match hd_path {
+        //     Some(hd_path) => LedgerHDPath::Other(hd_path.to_string()),
+        //     None => LedgerHDPath::LedgerLive(mnemonic_index.unwrap_or(0)),
+        // };
+        //
+        // trace!(?chain_id, "Creating new ledger signer");
+        // Ok(Some(Ledger::new(derivation, chain_id).await.wrap_err("Ledger device not available.")?))
+        Ok(None)
     }
 }
 

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -292,7 +292,7 @@ impl CallTraceDecoder {
         if let RawOrDecodedLog::Raw(raw_log) = log {
             // do not attempt decoding if no topics
             if raw_log.topics.is_empty() {
-                return
+                return;
             }
 
             let mut events = vec![];
@@ -326,7 +326,7 @@ impl CallTraceDecoder {
                             })
                             .collect(),
                     );
-                    break
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Remove functionality that would cause TestArgs::execute_tests() be a future that is not Send. That broke functionality in Phylax. This functionality will not be used eitherway in Phylax.